### PR TITLE
Don't throw a fatal exception when an empty jar is on the classpath.

### DIFF
--- a/rt/vm/src/main/java/org/apidesign/vm4brwsr/VM.java
+++ b/rt/vm/src/main/java/org/apidesign/vm4brwsr/VM.java
@@ -899,9 +899,6 @@ abstract class VM extends ByteCodeToJavaScript {
         @Override
         protected void generateEpilogue(Appendable out) throws IOException {
             out.append("});");
-            if (exportedCount == 0) {
-                System.err.println("Creating library without any exported symbols is (most often) useless!");
-            }
         }
 
         @Override

--- a/rt/vm/src/main/java/org/apidesign/vm4brwsr/VM.java
+++ b/rt/vm/src/main/java/org/apidesign/vm4brwsr/VM.java
@@ -900,7 +900,7 @@ abstract class VM extends ByteCodeToJavaScript {
         protected void generateEpilogue(Appendable out) throws IOException {
             out.append("});");
             if (exportedCount == 0) {
-                throw new IOException("Creating library without any exported symbols is useless!");
+                System.err.println("Creating library without any exported symbols is (most often) useless!");
             }
         }
 


### PR DESCRIPTION
Fix for https://github.com/jtulach/bck2brwsr/issues/21