### PR TITLE
allow to start threads

### DIFF
--- a/rt/emul/mini/src/main/java/java/lang/Thread.java
+++ b/rt/emul/mini/src/main/java/java/lang/Thread.java
@@ -26,6 +26,7 @@
 package java.lang;
 
 import java.util.Map;
+import org.apidesign.bck2brwsr.core.JavaScriptBody;
 
 
 /**
@@ -504,8 +505,16 @@ class Thread implements Runnable {
      * @see        #stop()
      */
     public void start() {
-        throw new SecurityException();
+        startBlueThread(target);
     }
+
+    @JavaScriptBody(args = "r", body =
+        "window.setTimeout(function() {\n" +
+        "  r.run__V();\n" +
+        "}, 0);\n"
+    )
+    private static native void startBlueThread(Runnable r);
+
 
     /**
      * If this thread was constructed using a separate
@@ -844,7 +853,6 @@ class Thread implements Runnable {
      * @see        ThreadGroup#getMaxPriority()
      */
     public final void setPriority(int newPriority) {
-        throw new SecurityException();
     }
 
     /**

--- a/rt/emul/mini/src/main/java/java/lang/Thread.java
+++ b/rt/emul/mini/src/main/java/java/lang/Thread.java
@@ -853,6 +853,7 @@ class Thread implements Runnable {
      * @see        ThreadGroup#getMaxPriority()
      */
     public final void setPriority(int newPriority) {
+        // no-op
     }
 
     /**
@@ -880,7 +881,7 @@ class Thread implements Runnable {
      * @see        #checkAccess()
      */
     public final void setName(String name) {
-        throw new SecurityException();
+        this.name = name;
     }
 
     /**
@@ -1071,7 +1072,7 @@ class Thread implements Runnable {
      *          thread cannot modify this thread
      */
     public final void setDaemon(boolean on) {
-        throw new SecurityException();
+        // no-op
     }
 
     /**
@@ -1098,7 +1099,7 @@ class Thread implements Runnable {
      * @see        SecurityManager#checkAccess(Thread)
      */
     public final void checkAccess() {
-        throw new SecurityException();
+        // no-op
     }
 
     /**
@@ -1472,7 +1473,7 @@ class Thread implements Runnable {
      * @since 1.5
      */
     public static void setDefaultUncaughtExceptionHandler(UncaughtExceptionHandler eh) {
-        throw new SecurityException();
+        defaultUncaughtExceptionHandler = eh;
     }
 
     /**


### PR DESCRIPTION
Fix for #32 
A call to Thread.start() will use javascript to run the target "as soon as possible".