### PR TITLE
Fix #38

### DIFF
--- a/rt/emul/mini/src/main/java/java/lang/Class.java
+++ b/rt/emul/mini/src/main/java/java/lang/Class.java
@@ -167,7 +167,8 @@ public final
             return arrType;
         }
         try {
-            final String inJsName = className.replace('.', '_');
+            final String inJsName0 = className.replace("_", "_1");
+            final String inJsName = inJsName0.replace('.', '_');
             Class<?> c = loadCls(className, inJsName);
             if (c == null) {
                 c = loadCls(className, inJsName);

--- a/rt/vm11/src/test/java/org/apidesign/bck2brwsr/vm11/JFXIssuesTest.java
+++ b/rt/vm11/src/test/java/org/apidesign/bck2brwsr/vm11/JFXIssuesTest.java
@@ -139,6 +139,21 @@ public class JFXIssuesTest {
         return "CompiledOK";
     }
 
+    class Foo_Bar {
+        public Foo_Bar() {}
+    }
+
+    @Compare
+    public boolean underscoreClass() {
+        int err = 0;
+        try {
+            Class answer = Class.forName("org.apidesign.bck2brwsr.vm11.JFXIssuesTest$Foo_Bar");
+        } catch (ClassNotFoundException ex) {
+            err = 1;
+        }
+        return err == 0;
+    }
+
     @Factory public static Object[] create() {
         return VMTest.create(JFXIssuesTest.class);
     }


### PR DESCRIPTION
Classes with an underscore should first escape the underscore
Test fails before and succeeds after patch.