### PR TITLE
simple mapping of native methods to javascript implementations.

### DIFF
--- a/rt/vm/src/main/java/org/apidesign/vm4brwsr/ByteCodeParser.java
+++ b/rt/vm/src/main/java/org/apidesign/vm4brwsr/ByteCodeParser.java
@@ -2000,6 +2000,10 @@ final class ByteCodeParser {
             return false;
         }
 
+        public boolean isNative() {
+           return ((access & ACC_NATIVE) != 0);
+        }
+
         /**
          * Return max depth of operand stack.
          */

--- a/rt/vm/src/main/java/org/apidesign/vm4brwsr/ByteCodeToJavaScript.java
+++ b/rt/vm/src/main/java/org/apidesign/vm4brwsr/ByteCodeToJavaScript.java
@@ -518,6 +518,12 @@ abstract class ByteCodeToJavaScript {
                    out.append(jc.getClassName()).append('.')
                    .append(m.getName()).append("';\n");
                 }
+                if (m.isNative()) {
+                    out.append("return native_").append(className(jc)).append('_')
+                            .append(m.getName()).append("(");
+                    lmapper.outputArguments(out, m.isStatic());
+                    out.append(");\n");
+                }
             }
             if (defineProp) {
                 out.append("}});");


### PR DESCRIPTION
This fixes #42 
As an example, native methods in JavaFX rendering code 
For example:

```
private static native void nTexSubImage2D0(int target, int level,
            int xoffset, int yoffset, int width, int height, int format,
            int type, Object pixels, int pixelsByteOffset);
```

(see https://github.com/openjdk/jfx/blob/master/modules/javafx.graphics/src/main/java/com/sun/prism/es2/GLContext.java#L185)

maps to

```
function native_com_sun_prism_es2_GLContext_nTexSubImage2D0(target, level,
        xoffset, yoffset, width, height, format, type, pixels, pixelsByteOffset) {
```

(see https://github.com/gluonhq/uongl/blob/master/src/main/javascript/uongl.js#L451)

This allows existing libraries with JNI to be used without having access to the code.