### PR TITLE
Do not require currentScript relative URL to contain a slash

### DIFF
--- a/rt/vm/src/main/java/org/apidesign/vm4brwsr/VM.java
+++ b/rt/vm/src/main/java/org/apidesign/vm4brwsr/VM.java
@@ -815,7 +815,7 @@ abstract class VM extends ByteCodeToJavaScript {
                 + "        csUrl = cs['src'];\n"
                 + "      }\n"
                 + "    }\n"
-                + "    var prefix = csUrl ? csUrl['replace'](/\\/[^\\/]*$/,'/') : '';\n"
+                + "    var prefix = csUrl ? csUrl['replace'](/[^\\/]*$/,'') : '';\n"
                 + "    extensions.push(extension);\n"
                 + "    var cp = config['classpath'];\n"
                 + "    if (cp) for (var i = 0; i < cp.length; i++) {\n"


### PR DESCRIPTION
The regex should match the last segment of the URL. This works in all cases except when the URL contains only one segment, in which case the regex matches nothing and the replacement is not carried out and the result is not a directory name.

Example: `csUrl = "main.js"; cp[i] = "lib/foo.js";`
Expected extension URL: `"lib/foo.js"`
Observed extension URL: `"main.jslib/foo.js"`

(I am referring to the variables near my edit, see the diff.)